### PR TITLE
Embed Title components in SectionLayout components

### DIFF
--- a/src/components/common/SectionLayout.jsx
+++ b/src/components/common/SectionLayout.jsx
@@ -1,5 +1,7 @@
 import styled from "styled-components";
 
+import { SectionTitle } from "@/components";
+
 const Section = styled.section`
   display: flex;
   flex-direction: column;
@@ -11,17 +13,11 @@ const Section = styled.section`
   }
 `;
 
-const Title = styled.h1`
-  font-size: calc(32px + 1.5vw);
-  color: var(--accent-color);
-  margin-bottom: 30px;
-`;
-
-const SectionLayout = ({ title, children }) => (
-  <Section>
-    <Title>{title}</Title>
-    {children}
-  </Section>
-);
-
-export default SectionLayout;
+export default function SectionLayout({ title, children }) {
+  return (
+    <Section>
+      <SectionTitle>{title}</SectionTitle>
+      {children}
+    </Section>
+  );
+}

--- a/src/components/common/SectionSubTitle.jsx
+++ b/src/components/common/SectionSubTitle.jsx
@@ -1,9 +1,11 @@
 import styled from "styled-components";
 
-const Title = styled.h2`
+const Title = styled.h3`
+  font-size: calc(1rem + 1.5vw);
   color: var(--accent-color);
+  margin-bottom: 30px;
 `;
 
-const SectionSubTitle = ({ children }) => <Title>{children}</Title>;
-
-export default SectionSubTitle;
+export default function SectionSubTitle({ children }) {
+  return <Title>{children}</Title>;
+}

--- a/src/components/common/SectionTitle.jsx
+++ b/src/components/common/SectionTitle.jsx
@@ -6,6 +6,6 @@ const Title = styled.h1`
   margin-bottom: 30px;
 `;
 
-export default function SectionTitle({ title }) {
-  return <Title>{title}</Title>;
+export default function SectionTitle({ children }) {
+  return <Title>{children}</Title>;
 }

--- a/src/components/common/SectionTitle.jsx
+++ b/src/components/common/SectionTitle.jsx
@@ -1,11 +1,11 @@
 import styled from "styled-components";
 
-const SectionText = styled.h1`
+const Title = styled.h1`
+  font-size: calc(32px + 1.5vw);
   color: var(--accent-color);
+  margin-bottom: 30px;
 `;
 
-const SectionTitle = ({ title }) => {
-  return <SectionText>{title}</SectionText>;
-};
-
-export default SectionTitle;
+export default function SectionTitle({ title }) {
+  return <Title>{title}</Title>;
+}

--- a/src/components/common/SubSectionLayout.jsx
+++ b/src/components/common/SubSectionLayout.jsx
@@ -2,23 +2,23 @@ import styled from "styled-components";
 
 import { SectionSubTitle } from "@/components";
 
-const SubSection = styled.section`
-  max-width: 480px;
+const SubSectionContainer = styled.section`
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 1rem;
+  margin: 16px 0;
 
   @media only screen and (min-width: 751px) {
-    margin-top: 2rem;
+    margin-top: 32px;
   }
 `;
 
-const SubSectionLayout = ({ title, children }) => (
-  <SubSection>
-    <SectionSubTitle>{title}</SectionSubTitle>
-    {children}
-  </SubSection>
-);
-
-export default SubSectionLayout;
+export default function SubSectionLayout({ title, children }) {
+  return (
+    <SubSectionContainer>
+      <SectionSubTitle>{title}</SectionSubTitle>
+      {children}
+    </SubSectionContainer>
+  );
+}

--- a/src/components/common/SubSectionLayout.jsx
+++ b/src/components/common/SubSectionLayout.jsx
@@ -1,5 +1,7 @@
 import styled from "styled-components";
 
+import { SectionSubTitle } from "@/components";
+
 const SubSection = styled.section`
   max-width: 480px;
   display: flex;
@@ -14,7 +16,7 @@ const SubSection = styled.section`
 
 const SubSectionLayout = ({ title, children }) => (
   <SubSection>
-    <Title>{title}</Title>
+    <SectionSubTitle>{title}</SectionSubTitle>
     {children}
   </SubSection>
 );

--- a/src/components/common/SubSectionLayout.jsx
+++ b/src/components/common/SubSectionLayout.jsx
@@ -12,12 +12,6 @@ const SubSection = styled.section`
   }
 `;
 
-const Title = styled.h3`
-  font-size: calc(1rem + 1.5vw);
-  color: var(--accent-color);
-  margin-bottom: 30px;
-`;
-
 const SubSectionLayout = ({ title, children }) => (
   <SubSection>
     <Title>{title}</Title>


### PR DESCRIPTION
## Proposed Changes

#### Code changes

- Replace the arrow functions with the regular functions
- Update styles of `<SectionTitle />` and `<SectionSubTitle />`
- Embed Title components in SectionLayout components

#### Issues affected

_TODO: Which GitHub issues does this PR affect?_

- Resolves #31

## Additional Info
## Screenshots and/or video

## Testing Plan

- Use the UI with Google developer tools to check if there is a design collapse
- Check if there is no error in the console logs when the page is rendered

## Checklist

#### Basics

- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)
