### PR TITLE
FIx horizontal padding of the Main component

### DIFF
--- a/src/components/main/Main.jsx
+++ b/src/components/main/Main.jsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 
 const MainSection = styled.main`
   width: 100%;
-  padding: 0 5%;
+  padding: 0 40px;
   margin-top: 70px;
 
   @media only screen and (min-width: 751px) {


### PR DESCRIPTION
## Proposed Changes

#### Code changes

- Change the horizontal padding of `<Main />`  to 40px

#### Issues affected

- Fixes #33

## Additional Info

- none

## Screenshots and/or video

### Before
![image](https://user-images.githubusercontent.com/110521018/214917980-1f8a459c-84e6-4ddf-9334-7bd6d0b46468.png)

### After
![image](https://user-images.githubusercontent.com/110521018/214918054-5a7a4268-1403-4742-a20c-544b464f0a10.png)

## Testing Plan

- Check with Google developer tools if there is no design collapse

## Checklist

#### Basics

- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)
