### PR TITLE
Implement in-page navigation to sections in main

### DIFF
--- a/src/components/common/SectionLayout.jsx
+++ b/src/components/common/SectionLayout.jsx
@@ -13,9 +13,9 @@ const Section = styled.section`
   }
 `;
 
-export default function SectionLayout({ title, children }) {
+export default function SectionLayout({ id, title, children }) {
   return (
-    <Section>
+    <Section id={id}>
       <SectionTitle>{title}</SectionTitle>
       {children}
     </Section>

--- a/src/components/common/SectionLayout.jsx
+++ b/src/components/common/SectionLayout.jsx
@@ -6,10 +6,10 @@ const Section = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 4rem;
+  margin-top: 48px;
 
   @media only screen and (min-width: 751px) {
-    margin-top: 6rem;
+    margin-top: 96px;
   }
 `;
 


### PR DESCRIPTION
## Proposed Changes

#### Code changes

- Added `id` props to `<SectionLayout />`
- Replaced `margin-top` units `rem` with `px`

#### Issues affected

- Resolves #35 

## Additional Info

- The Intro section does not contain <SectionLayout /> and its id is hard coded, which needs to be fixed as well soon

## Screenshots and/or video

- I created dummy sections with corresponding ids of each section to demonstrate the in-page navigation

![in-page-navigation](https://user-images.githubusercontent.com/110521018/214979795-520537b7-0757-4c4a-b31f-dbe25ecf5a91.gif)

## Testing Plan

- Create dummy sections that are made of `<SectionLayout />` with ids  and check the navigation in the development server

## Checklist

#### Basics

- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)
