### PR TITLE
Create a reusable component LinkButton

### DIFF
--- a/src/components/common/LinkButton.jsx
+++ b/src/components/common/LinkButton.jsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+import styled from "styled-components";
+
+import { MEDIA_TABLET } from "@/constants";
+
+const Button = styled(Link)`
+  width: 150px;
+  display: inline-block;
+  color: var(--accent-color);
+  border: 2px solid var(--accent-color);
+  border-radius: 3px;
+  text-align: center;
+  padding: 10px 0;
+
+  &:hover {
+    color: var(--main-color);
+    background-color: var(--accent-color);
+    transition-duration: 1s;
+  }
+
+  @media only screen and (min-width: ${MEDIA_TABLET}) {
+    width: 220px;
+    font-size: 24px;
+  }
+`;
+
+export default function LinkButton({ href, children }) {
+  return <Button href={href}>{children}</Button>;
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -5,6 +5,7 @@ export { default as SectionTitle } from "./common/SectionTitle";
 export { default as SectionSubTitle } from "./common/SectionSubTitle";
 export { default as SectionLayout } from "./common/SectionLayout";
 export { default as SubSectionLayout } from "./common/SubSectionLayout";
+export { default as LinkButton } from "./common/LinkButton";
 
 /*
  * Header


### PR DESCRIPTION
## Proposed Changes

#### Code changes

- Created a reusable component `<LinkButton />` in `/src/components/common`
- Added  `<LinkButton />` to the entry point

#### Issues affected

- Closes #41

## Additional Info

- none

## Screenshots and/or video

![commonButton](https://user-images.githubusercontent.com/110521018/215411294-de7b0c25-c576-486a-8d4a-63f1ed4f1e4e.gif)

## Testing Plan

### UI
- Add `<LinkButton />` in `pages/index.js`
- Check if there is no UI bug with Google developer tools 

## Checklist

#### Basics

- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)
