### PR TITLE
Add the bottom margin to the SectionLayout component

### DIFF
--- a/src/components/common/SectionLayout.jsx
+++ b/src/components/common/SectionLayout.jsx
@@ -8,10 +8,10 @@ const Section = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-top: 48px;
+  margin: 48px 0;
 
   @media only screen and (min-width: ${MEDIA_TABLET}) {
-    margin-top: 96px;
+    margin: 96px 0;
   }
 `;
 


### PR DESCRIPTION
## Proposed Changes

#### Code changes

- Added the bottom margin of `<SectionLayout />`

#### Issues affected

- Fixes #46

## Additional Info

-  `<SectionLayout />` has `margin-top` and there is already space between sections created so far, so adding the bottom margin won't affect other UIs.

## Screenshots and/or video

### Before modification

![image](https://user-images.githubusercontent.com/110521018/215889924-6b770596-c5e1-42bf-954c-64890fa0ad6c.png)

### After modification

![image](https://user-images.githubusercontent.com/110521018/215893269-e6b3af2b-c3e0-43c6-8e48-3e5d0d6b099e.png)

## Testing Plan

- Check if there are no other UIs affected by this change with Google developer tools

## Checklist

#### Basics

- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)
