### PR TITLE
Update Head with additional metadata

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,8 +1,9 @@
-import { GlobalStyle } from "@/components";
+import { CustomHead, GlobalStyle } from "@/components";
 
 export default function App({ Component, pageProps }) {
   return (
     <>
+      <CustomHead />
       <GlobalStyle />
       <Component {...pageProps} />
     </>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,10 @@
 /*
+ * Meta data
+ */
+
+export { default as CustomHead } from "./meta/CustomHead";
+
+/*
  * Styles
  */
 export { default as GlobalStyle } from "./styles/GlobalStyle";

--- a/src/components/meta/CustomHead.jsx
+++ b/src/components/meta/CustomHead.jsx
@@ -1,0 +1,19 @@
+import Head from "next/head";
+
+import { META_DATA } from "@/constants";
+
+export default function CustomHead() {
+  return (
+    <Head>
+      {Object.keys(META_DATA).map((data, idx) =>
+        data === "charset" ? (
+          <meta charSet={META_DATA["charset"]} key={idx} />
+        ) : data === "title" ? (
+          <title key={idx}>{META_DATA["title"]}</title>
+        ) : (
+          <meta name={data} content={META_DATA[data]} key={idx} />
+        )
+      )}
+    </Head>
+  );
+}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -22,6 +22,20 @@ export const PROFILE_IMG_SRC = "/assets/profile-img.jpg";
 export const NAME = "Hidemichi Shimura";
 export const EMAIL = "hidemichi.shimura@gmail.com";
 export const CURRENT_YEAR = "2023";
+export const JOB_TITLE = "front-end developer";
+
+/*
+ * Meta data
+ */
+export const META_DATA = {
+  title: `${NAME} | ${JOB_TITLE}`,
+  charset: "utf-8",
+  viewport: "width=device-width, initial-scale=1.0",
+  description: `${NAME}'s portfolio website`,
+  keywords:
+    "HTML, CSS, JavaScript, React, Next.js, styled-components CSS-in-JS",
+  author: NAME,
+};
 
 /*
  * Header


### PR DESCRIPTION
## Proposed Changes

- This PR brings additional metadata to the Head

#### Code changes

- Created the `CustomHead` component in `src/meta`
- Added necessary constants for `CustomHead` in `src/constants/index.js`
- Added `CustomHead` to the entry point
- Embedded `CustomHead` in `pages/_app.js`

#### Issues affected

- Closes #52

## Additional Info

- `CustomHead` is embedded in `_app.js` instead of `_document.js` to avoid the errors below.
  - [<title> should not be used in _document.js's <Head>](https://nextjs.org/docs/messages/no-document-title) 
  - [Viewport meta tags should not be used in _document.js's <Head>](https://nextjs.org/docs/messages/no-document-viewport-meta)

## Screenshots and/or video

<img width="1034" alt="metadata-screenshot" src="https://user-images.githubusercontent.com/110521018/224427812-1a98befc-c941-4b99-81ae-2340c0927ae0.png">

## Testing Plan

- Check with the google developer tools if all the metadata is properly embedded

## Checklist

#### Basics

- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)
