### PR TITLE
Fix the height of the Intro section

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -4,7 +4,7 @@ import { HeaderLogo, BurgerMenu, NavMenu } from "@/components";
 
 const StyledHeader = styled.header`
   width: 100%;
-  height: 70px;
+  height: var(--header-height);
   padding: 0 32px;
   border-bottom: 1px solid var(--accent-color);
   display: flex;

--- a/src/components/main/intro/Intro.jsx
+++ b/src/components/main/intro/Intro.jsx
@@ -1,8 +1,11 @@
 import styled from "styled-components";
 
-import { PROFILE_IMG_SRC, INTRO_HEADING, INTRO_DESCRIPTION } from "@/constants";
-
-import { MEDIA_TABLET } from "@/constants";
+import {
+  MEDIA_TABLET,
+  PROFILE_IMG_SRC,
+  INTRO_HEADING,
+  INTRO_DESCRIPTION,
+} from "@/constants";
 
 const IntroSection = styled.section`
   width: 100%;

--- a/src/components/main/intro/Intro.jsx
+++ b/src/components/main/intro/Intro.jsx
@@ -6,6 +6,7 @@ import { MEDIA_TABLET } from "@/constants";
 
 const IntroSection = styled.section`
   width: 100%;
+  height: calc(100vh - var(--header-height));
   display: flex;
   align-items: center;
 `;
@@ -20,11 +21,9 @@ const IntroWrapper = styled.div`
 const IntroHeading = styled.h1`
   font-size: 1.5rem;
   color: var(--accent-color);
-  margin-top: 50px;
 
   @media only screen and (min-width: ${MEDIA_TABLET}) {
     font-size: 2.5rem;
-    margin-top: 80px;
   }
 `;
 

--- a/src/components/styles/GlobalStyle.jsx
+++ b/src/components/styles/GlobalStyle.jsx
@@ -18,6 +18,7 @@ const GlobalStyle = createGlobalStyle`
     --main-color: #000000;
     --text-color: #ffffff;
     --accent-color: #fef2b2;
+    --header-height: 70px;
   }
 
   body {


### PR DESCRIPTION
## Proposed Changes

- This PR indicates a change to the Intro section's height

#### Code changes

- Added the CSS variable for `Header`'s height `--header-height: 70px`
- Changed `height` of `IntroSection`
- Replaced `Header`'s height with `--header-height: 70px`
- Included `MEDIA_TABLET` in the second import statement of `Intro`
- Removed unnecessary `margin-top` of `IntroHeading`

#### Issues affected

- Fixes #59 

## Additional Info

- none

## Screenshots and/or video

- Smartphone
![image](https://user-images.githubusercontent.com/110521018/224453684-27b678f8-24b2-4a5f-846b-4a7d580a7f80.png)

- Tablet
![image](https://user-images.githubusercontent.com/110521018/224453702-cc27630e-cf71-417d-9505-725d6f0f8df1.png)

- Laptop
![image](https://user-images.githubusercontent.com/110521018/224453717-a5c16b95-af5d-4a01-9c5f-46fdc14cc112.png)

## Testing Plan

- Check if the header's height is not affected by this change and if the Intro section has more height added

## Checklist

#### Basics

- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)
