### PR TITLE
Styling all the headings with a gradient color

### DIFF
--- a/src/components/common/SectionSubTitle.jsx
+++ b/src/components/common/SectionSubTitle.jsx
@@ -4,6 +4,30 @@ const Title = styled.h3`
   font-size: calc(1rem + 1.5vw);
   color: var(--accent-color);
   margin-bottom: 30px;
+
+  // Linear gradient animation
+  background-image: linear-gradient(
+    90deg,
+    var(--accent-color) 0%,
+    var(--text-color) 40%,
+    var(--accent-color) 80%
+  );
+  background-size: 200% auto;
+  background-clip: text;
+  text-fill-color: transparent;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: textclip 3s ease-in-out infinite;
+  display: inline-block;
+
+  @keyframes textclip {
+    to {
+      background-position: 200% center;
+    }
+  }
+
+  border: 3px solid border-image: radial-gradient(rgb(0,143,104), rgb(250,224,66));
+  }
 `;
 
 export default function SectionSubTitle({ children }) {

--- a/src/components/common/SectionTitle.jsx
+++ b/src/components/common/SectionTitle.jsx
@@ -4,6 +4,27 @@ const Title = styled.h1`
   font-size: calc(32px + 1.5vw);
   color: var(--accent-color);
   margin-bottom: 30px;
+
+  // Linear gradient animation
+  background-image: linear-gradient(
+    90deg,
+    var(--main-color) 0%,
+    var(--accent-color) 40%,
+    var(--main-color) 80%
+  );
+  background-size: 200% auto;
+  background-clip: text;
+  text-fill-color: transparent;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: textclip 3s ease-in-out infinite;
+  display: inline-block;
+
+  @keyframes textclip {
+    to {
+      background-position: 200% center;
+    }
+  }
 `;
 
 export default function SectionTitle({ children }) {

--- a/src/components/main/intro/Intro.jsx
+++ b/src/components/main/intro/Intro.jsx
@@ -25,6 +25,27 @@ const IntroHeading = styled.h1`
   font-size: 1.5rem;
   color: var(--accent-color);
 
+  // Linear gradient animation
+  background-image: linear-gradient(
+    90deg,
+    var(--accent-color) 0%,
+    var(--text-color) 40%,
+    var(--accent-color) 80%
+  );
+  background-size: 200% auto;
+  background-clip: text;
+  text-fill-color: transparent;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: textclip 3s ease-in-out infinite;
+  display: inline-block;
+
+  @keyframes textclip {
+    to {
+      background-position: 200% center;
+    }
+  }
+
   @media only screen and (min-width: ${MEDIA_TABLET}) {
     font-size: 2.5rem;
   }

--- a/src/components/styles/GlobalStyle.jsx
+++ b/src/components/styles/GlobalStyle.jsx
@@ -15,7 +15,7 @@ const GlobalStyle = createGlobalStyle`
   }
 
   :root {
-    --main-color: #252525;
+    --main-color: #171717;
     --text-color: #ffffff;
     --accent-color: #fef2b2;
     --header-height: 70px;

--- a/src/components/styles/GlobalStyle.jsx
+++ b/src/components/styles/GlobalStyle.jsx
@@ -15,7 +15,7 @@ const GlobalStyle = createGlobalStyle`
   }
 
   :root {
-    --main-color: #000000;
+    --main-color: #252525;
     --text-color: #ffffff;
     --accent-color: #fef2b2;
     --header-height: 70px;


### PR DESCRIPTION
## Proposed Changes

- This PR indicates an additional style to the headings with a gradient color

#### Code changes

- Changed the value of `--main-color` in `GlobalStyle`
- Added a gradient color with animation to `SectionSubTitle`, `SectionTitle`, and `IntroHeading`

#### Issues affected

- Resolves #63

## Additional Info

- none

## Screenshots and/or video

### Before
![image](https://user-images.githubusercontent.com/110521018/224892214-524fc44e-58b0-44d9-9f7a-b33fd016a204.png)

### After
![gradient-color](https://user-images.githubusercontent.com/110521018/224892415-554a3e76-8f03-4072-862c-3f5540eddc1d.gif)

## Testing Plan

- Check if the gradient color is properly applied with the Google developer tools

## Checklist

#### Basics

- [x] Local QA is complete
- [x] No debugging `console.log()` statements
- [x] Commented-out code removed
- [x] Unused code removed (imports, functions, styles, etc - if it's not used anywhere, it's not in this PR)
